### PR TITLE
Add TerminalValuer interface

### DIFF
--- a/examples/TerminalValuer/main.go
+++ b/examples/TerminalValuer/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+
+	"github.com/fornellas/slogxt/log"
+)
+
+func main() {
+	slog.Info("=== TerminalValuer Demo ===")
+
+	// Create sample colored values using TerminalValue
+	diff := log.NewTerminalValue("\033[31m-old line\033[0m\n\033[32m+new line\033[0m")
+
+	// This contains unsafe ANSI sequences that will be filtered
+	unsafeDiff := log.NewTerminalValue("\033[2J\033[31mred text\033[H\033[0m")
+
+	status := log.NewTerminalValue("\033[32m✓\033[0m Operation completed successfully")
+
+	// Demo 1: TerminalTreeHandler shows ANSI colors
+	slog.Info("\n1. Terminal Tree Handler (with colors):")
+	termHandler := log.NewTerminalTreeHandler(os.Stdout, &log.TerminalHandlerOptions{
+		ForceColor: true, // Force colors even if not a TTY
+	})
+	termLogger := slog.New(termHandler)
+
+	termLogger.Info("File changes applied", "diff", diff)
+	termLogger.Info("Status update", "status", status)
+	termLogger.Info("Unsafe ANSI filtered", "diff", unsafeDiff)
+
+	// Demo 2: JSON Handler shows plain text
+	slog.Info("\n2. JSON Handler (plain text):")
+	jsonBuf := &bytes.Buffer{}
+	jsonHandler := slog.NewJSONHandler(jsonBuf, nil)
+	jsonLogger := slog.New(jsonHandler)
+
+	jsonLogger.Info("File changes applied", "diff", diff)
+	jsonLogger.Info("Status update", "status", status)
+	jsonLogger.Info("Unsafe ANSI filtered", "diff", unsafeDiff)
+
+	slog.Info("JSON Output:")
+	os.Stdout.WriteString(jsonBuf.String())
+
+	// Demo 3: TerminalLineHandler
+	slog.Info("3. Terminal Line Handler (with colors):")
+	lineHandler := log.NewTerminalLineHandler(os.Stdout, &log.TerminalHandlerOptions{
+		ForceColor: true,
+	})
+	lineLogger := slog.New(lineHandler)
+
+	lineLogger.Info("File changes applied", "diff", diff)
+	lineLogger.Info("Status update", "status", status)
+
+	slog.Info("\n=== End Demo ===")
+}

--- a/log/terminal_line_handler.go
+++ b/log/terminal_line_handler.go
@@ -92,7 +92,15 @@ func (aw *terminalLineHandlerAttrWriter) writeAttr(
 			return nt + n, err
 		}
 
-		if n, err = aw.colorScheme.AttrValue.Fprintf(w, "%s", escape(attr.Value.String())); err != nil {
+		var valueStr string
+		if tv, ok := attr.Value.Any().(TerminalValuer); ok {
+			terminalValue := tv.TerminalValue()
+			valueStr = sanitizeANSI(terminalValue.String())
+		} else {
+			valueStr = escape(attr.Value.String())
+		}
+
+		if n, err = aw.colorScheme.AttrValue.Fprintf(w, "%s", valueStr); err != nil {
 			return nt + n, err
 		}
 		nt += n

--- a/log/terminal_valuer.go
+++ b/log/terminal_valuer.go
@@ -1,0 +1,258 @@
+package log
+
+import (
+	"log/slog"
+	"strconv"
+	"strings"
+)
+
+// TerminalValuer is implemented by any value that wants to provide
+// a terminal representation for slogxt terminal handlers.
+// This allows values to include ANSI escape sequences that will be
+// sanitized and displayed in terminal output while still working
+// correctly with other handlers (like JSON) which will use the
+// standard String() method or LogValue() method.
+type TerminalValuer interface {
+	// TerminalValue returns a slog.Value that may contain any
+	// ANSI escape sequences. Terminal handlers will sanitize
+	// these sequences to keep only safe formatting codes.
+	TerminalValue() slog.Value
+}
+
+// isCSIStart checks if the current position starts a CSI sequence
+func isCSIStart(runes []rune, i int) bool {
+	return i < len(runes)-1 && runes[i] == '\033' && runes[i+1] == '['
+}
+
+// parseANSIParameters parses the numeric parameters of an ANSI sequence
+func parseANSIParameters(runes []rune, i *int) []rune {
+	var params []rune
+	for *i < len(runes) && (runes[*i] >= '0' && runes[*i] <= '9' || runes[*i] == ';') {
+		params = append(params, runes[*i])
+		*i++
+	}
+	return params
+}
+
+// escapeRune returns the escaped representation of a non-printable rune.
+func escapeRune(r rune) string {
+	e := strconv.QuoteRune(r)
+	return e[1 : len(e)-1] // Remove the surrounding quotes
+}
+
+// isValidANSICommand checks if a character is a valid ANSI command character.
+func isValidANSICommand(cmd rune) bool {
+	// Only allow actual ANSI CSI command characters
+	switch cmd {
+	case 'A', 'B', 'C', 'D': // Cursor movement
+		return true
+	case 'E', 'F': // Cursor next/previous line
+		return true
+	case 'G': // Cursor horizontal absolute
+		return true
+	case 'H', 'f': // Cursor position
+		return true
+	case 'J': // Erase in display
+		return true
+	case 'K': // Erase in line
+		return true
+	case 'S', 'T': // Scroll up/down
+		return true
+	case 'm': // SGR (Select Graphic Rendition) - colors and formatting
+		return true
+	case 'n': // Device status report
+		return true
+	case 's', 'u': // Save/restore cursor position
+		return true
+	default:
+		return false
+	}
+}
+
+// isSafeSGRCode checks if a single SGR code is safe
+func isSafeSGRCode(param string) bool {
+	code, err := strconv.Atoi(param)
+	if err != nil {
+		return false
+	}
+
+	// Allow safe SGR codes:
+	// 0: reset, 1-9: formatting, 30-37: fg colors, 40-47: bg colors
+	// 90-97: bright fg colors, 100-107: bright bg colors
+	return code == 0 ||
+		(code >= 1 && code <= 9) ||
+		(code >= 30 && code <= 37) ||
+		(code >= 40 && code <= 47) ||
+		(code >= 90 && code <= 97) ||
+		(code >= 100 && code <= 107)
+}
+
+// isSafeSGRParameters checks if SGR parameters are safe
+func isSafeSGRParameters(params string) bool {
+	if params == "" {
+		return true // Reset
+	}
+
+	for _, param := range strings.Split(params, ";") {
+		if param == "" {
+			continue
+		}
+		if !isSafeSGRCode(param) {
+			return false
+		}
+	}
+	return true
+}
+
+// isSafeANSICommand determines if an ANSI command is safe for terminal output.
+func isSafeANSICommand(cmd rune, params string) bool {
+	if cmd != 'm' {
+		// Block all non-SGR CSI sequences (cursor movement, screen clearing, etc.)
+		return false
+	}
+	return isSafeSGRParameters(params)
+}
+
+// processRegularCharacter processes a non-ANSI character and returns the next position
+func processRegularCharacter(runes []rune, i int, result *[]rune) int {
+	r := runes[i]
+	if r == '\t' || strconv.IsPrint(r) {
+		*result = append(*result, r)
+	} else {
+		escaped := escapeRune(r)
+		*result = append(*result, []rune(escaped)...)
+	}
+	return i + 1
+}
+
+// processRegularCharacterForStripping processes a non-ANSI character for stripping
+func processRegularCharacterForStripping(runes []rune, i int, result *[]rune) int {
+	r := runes[i]
+	if r == '\t' || r == '\n' || r == '\r' || strconv.IsPrint(r) {
+		*result = append(*result, r)
+	} else {
+		escaped := escapeRune(r)
+		*result = append(*result, []rune(escaped)...)
+	}
+	return i + 1
+}
+
+// processANSISequence processes an ANSI escape sequence and returns the next position
+func processANSISequence(runes []rune, i int, result *[]rune) int {
+	start := i
+	i += 2 // Skip '\033['
+
+	// Parse parameters
+	params := parseANSIParameters(runes, &i)
+
+	if i >= len(runes) {
+		// Incomplete sequence, skip it
+		return len(runes)
+	}
+
+	cmd := runes[i]
+	if isValidANSICommand(cmd) {
+		if isSafeANSICommand(cmd, string(params)) {
+			// Include the safe ANSI sequence
+			for j := start; j <= i; j++ {
+				*result = append(*result, runes[j])
+			}
+		}
+		return i + 1
+	}
+
+	// Invalid command, process as regular character
+	return processRegularCharacter(runes, i, result)
+}
+
+// stripANSISequence processes and strips an ANSI escape sequence
+func stripANSISequence(runes []rune, i int, result *[]rune) int {
+	i += 2 // Skip '\033['
+
+	// Skip parameters
+	for i < len(runes) && (runes[i] >= '0' && runes[i] <= '9' || runes[i] == ';') {
+		i++
+	}
+
+	if i >= len(runes) {
+		// Incomplete sequence, skip it
+		return len(runes)
+	}
+
+	cmd := runes[i]
+	if isValidANSICommand(cmd) {
+		// Valid ANSI sequence, skip it entirely
+		return i + 1
+	}
+
+	// Invalid command, process as regular character
+	return processRegularCharacterForStripping(runes, i, result)
+}
+
+// sanitizeANSI removes dangerous ANSI escape sequences while preserving
+// safe color and formatting sequences. It allows:
+// - Color changes (30-37, 90-97, 40-47, 100-107)
+// - Text formatting (bold, dim, italic, underline, etc.)
+// - Reset sequences
+// But blocks:
+// - Cursor movement
+// - Screen clearing
+// - Other potentially disruptive sequences
+func sanitizeANSI(s string) string {
+	result := make([]rune, 0, len(s))
+	runes := []rune(s)
+
+	for i := 0; i < len(runes); {
+		if isCSIStart(runes, i) {
+			i = processANSISequence(runes, i, &result)
+		} else {
+			i = processRegularCharacter(runes, i, &result)
+		}
+	}
+
+	return string(result)
+}
+
+// stripANSI removes all ANSI escape sequences from a string
+func stripANSI(s string) string {
+	result := make([]rune, 0, len(s))
+	runes := []rune(s)
+
+	for i := 0; i < len(runes); {
+		if isCSIStart(runes, i) {
+			i = stripANSISequence(runes, i, &result)
+		} else {
+			i = processRegularCharacterForStripping(runes, i, &result)
+		}
+	}
+
+	return string(result)
+}
+
+// TerminalValue represents a string value that may contain ANSI escape sequences.
+// It automatically provides different representations for terminal vs. other handlers:
+// - String() and MarshalText() return the text with all ANSI sequences removed
+// - TerminalValue() returns the original text with ANSI sequences for terminal handlers
+type TerminalValue struct {
+	text string
+}
+
+// NewTerminalValue creates a new TerminalValue from a string that may contain ANSI sequences
+func NewTerminalValue(text string) TerminalValue {
+	return TerminalValue{text: text}
+}
+
+// String returns the text with all ANSI escape sequences removed
+func (tv TerminalValue) String() string {
+	return stripANSI(tv.text)
+}
+
+// MarshalText implements encoding.TextMarshaler for JSON compatibility
+func (tv TerminalValue) MarshalText() ([]byte, error) {
+	return []byte(tv.String()), nil
+}
+
+// TerminalValue implements TerminalValuer, returning the original text with ANSI sequences
+func (tv TerminalValue) TerminalValue() slog.Value {
+	return slog.StringValue(tv.text)
+}

--- a/log/terminal_valuer_test.go
+++ b/log/terminal_valuer_test.go
@@ -1,0 +1,534 @@
+package log
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestColoredValue implements TerminalValuer for testing
+type TestColoredValue struct {
+	plainText    string
+	terminalText string
+}
+
+func (v TestColoredValue) String() string {
+	return v.plainText
+}
+
+func (v TestColoredValue) TerminalValue() slog.Value {
+	return slog.StringValue(v.terminalText)
+}
+
+func TestSanitizeANSI(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "safe_color_codes",
+			input:    "\033[31mred\033[0m \033[32mgreen\033[0m",
+			expected: "\033[31mred\033[0m \033[32mgreen\033[0m",
+		},
+		{
+			name:     "safe_formatting_codes",
+			input:    "\033[1mbold\033[0m \033[3mitalic\033[0m \033[4munderline\033[0m",
+			expected: "\033[1mbold\033[0m \033[3mitalic\033[0m \033[4munderline\033[0m",
+		},
+		{
+			name:     "bright_colors",
+			input:    "\033[91mbright red\033[0m \033[104mbright blue bg\033[0m",
+			expected: "\033[91mbright red\033[0m \033[104mbright blue bg\033[0m",
+		},
+		{
+			name:     "cursor_movement_blocked",
+			input:    "\033[2Jclear screen\033[H\033[31mred\033[0m",
+			expected: "clear screen\033[31mred\033[0m",
+		},
+		{
+			name:     "cursor_position_blocked",
+			input:    "\033[10;5Hposition\033[32mgreen\033[0m",
+			expected: "position\033[32mgreen\033[0m",
+		},
+		{
+			name:     "erase_sequences_blocked",
+			input:    "\033[Kerase line\033[31mred\033[0m",
+			expected: "erase line\033[31mred\033[0m",
+		},
+		{
+			name:     "mixed_safe_and_unsafe",
+			input:    "\033[31mred\033[2J\033[1mbold\033[H\033[0mreset",
+			expected: "\033[31mred\033[1mbold\033[0mreset",
+		},
+		{
+			name:     "complex_sgr_parameters",
+			input:    "\033[31;1;4mred bold underline\033[0m",
+			expected: "\033[31;1;4mred bold underline\033[0m",
+		},
+		{
+			name:     "unsafe_sgr_codes",
+			input:    "\033[50munsafe\033[0m",
+			expected: "unsafe\033[0m",
+		},
+		{
+			name:     "non_printable_chars_escaped",
+			input:    "hello\x00world\x1f\x7f",
+			expected: "hello\\x00world\\x1f\\x7f",
+		},
+		{
+			name:     "tabs_preserved",
+			input:    "hello\tworld",
+			expected: "hello\tworld",
+		},
+		{
+			name:     "empty_string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no_ansi_sequences",
+			input:    "plain text",
+			expected: "plain text",
+		},
+		{
+			name:     "incomplete_ansi_sequence",
+			input:    "\033[31incomplete",
+			expected: "incomplete",
+		},
+		{
+			name:     "reset_only",
+			input:    "\033[mreset",
+			expected: "\033[mreset",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeANSI(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTerminalValuerWithTreeHandler(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     any
+		expected  string
+		shouldLog func(*slog.Logger)
+	}{
+		{
+			name: "terminal_valuer_with_colors",
+			value: TestColoredValue{
+				plainText:    "plain text",
+				terminalText: "\033[31mred text\033[0m",
+			},
+			expected: "  value: \033[31mred text\033[0m\n",
+			shouldLog: func(logger *slog.Logger) {
+				logger.Info("test message", "value", TestColoredValue{
+					plainText:    "plain text",
+					terminalText: "\033[31mred text\033[0m",
+				})
+			},
+		},
+		{
+			name: "terminal_valuer_unsafe_sequences_filtered",
+			value: TestColoredValue{
+				plainText:    "plain text",
+				terminalText: "\033[2J\033[31mred\033[H\033[0m",
+			},
+			expected: "  value: \033[31mred\033[0m\n",
+			shouldLog: func(logger *slog.Logger) {
+				logger.Info("test message", "value", TestColoredValue{
+					plainText:    "plain text",
+					terminalText: "\033[2J\033[31mred\033[H\033[0m",
+				})
+			},
+		},
+		{
+			name: "terminal_valuer_multiline",
+			value: TestColoredValue{
+				plainText:    "line1\nline2",
+				terminalText: "\033[31mline1\033[0m\n\033[32mline2\033[0m",
+			},
+			expected: "  value:\n    \033[31mline1\033[0m\n    \033[32mline2\033[0m\n",
+			shouldLog: func(logger *slog.Logger) {
+				logger.Info("test message", "value", TestColoredValue{
+					plainText:    "line1\nline2",
+					terminalText: "\033[31mline1\033[0m\n\033[32mline2\033[0m",
+				})
+			},
+		},
+		{
+			name:     "regular_value_still_escaped",
+			value:    "regular\x00text",
+			expected: "  value: regular\\x00text\n",
+			shouldLog: func(logger *slog.Logger) {
+				logger.Info("test message", "value", "regular\x00text")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			handler := NewTerminalTreeHandler(buf, &TerminalHandlerOptions{
+				NoColor: true,
+			})
+			logger := slog.New(handler)
+
+			tt.shouldLog(logger)
+
+			output := buf.String()
+			assert.Contains(t, output, tt.expected)
+		})
+	}
+}
+
+func TestTerminalValuerWithLineHandler(t *testing.T) {
+	tests := []struct {
+		name      string
+		expected  string
+		shouldLog func(*slog.Logger)
+	}{
+		{
+			name:     "terminal_valuer_with_colors",
+			expected: "[value: \033[31mred text\033[0m]",
+			shouldLog: func(logger *slog.Logger) {
+				logger.Info("test message", "value", TestColoredValue{
+					plainText:    "plain text",
+					terminalText: "\033[31mred text\033[0m",
+				})
+			},
+		},
+		{
+			name:     "terminal_valuer_unsafe_filtered",
+			expected: "[value: \033[31mred\033[0m]",
+			shouldLog: func(logger *slog.Logger) {
+				logger.Info("test message", "value", TestColoredValue{
+					plainText:    "plain text",
+					terminalText: "\033[2J\033[31mred\033[H\033[0m",
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			handler := NewTerminalLineHandler(buf, &TerminalHandlerOptions{
+				NoColor: true,
+			})
+			logger := slog.New(handler)
+
+			tt.shouldLog(logger)
+
+			output := buf.String()
+			assert.Contains(t, output, tt.expected)
+		})
+	}
+}
+
+// TestLogValue implements both LogValuer and TerminalValuer for JSON integration tests
+type TestLogValue struct {
+	plainText    string
+	terminalText string
+}
+
+func (v TestLogValue) String() string {
+	return v.plainText
+}
+
+func (v TestLogValue) LogValue() slog.Value {
+	return slog.StringValue(v.plainText)
+}
+
+func (v TestLogValue) TerminalValue() slog.Value {
+	return slog.StringValue(v.terminalText)
+}
+
+func TestTerminalValuerIntegration(t *testing.T) {
+	t.Run("json_handler_uses_logvalue_method", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		handler := slog.NewJSONHandler(buf, nil)
+		logger := slog.New(handler)
+
+		coloredValue := TestLogValue{
+			plainText:    "plain text",
+			terminalText: "\033[31mred text\033[0m",
+		}
+
+		logger.Info("test message", "value", coloredValue)
+
+		output := buf.String()
+		// JSON handler should use LogValue() method, not TerminalValue()
+		assert.Contains(t, output, "plain text")
+		assert.NotContains(t, output, "\033[31m")
+	})
+
+	t.Run("tree_handler_vs_json_handler", func(t *testing.T) {
+		coloredValue := TestColoredValue{
+			plainText:    "plain text",
+			terminalText: "\033[31mred text\033[0m",
+		}
+
+		// Terminal handler
+		termBuf := &bytes.Buffer{}
+		termHandler := NewTerminalTreeHandler(termBuf, &TerminalHandlerOptions{
+			NoColor: true,
+		})
+		termLogger := slog.New(termHandler)
+		termLogger.Info("test", "diff", coloredValue)
+		termOutput := termBuf.String()
+
+		// JSON handler with LogValue type
+		jsonValue := TestLogValue(coloredValue)
+		jsonBuf := &bytes.Buffer{}
+		jsonHandler := slog.NewJSONHandler(jsonBuf, nil)
+		jsonLogger := slog.New(jsonHandler)
+		jsonLogger.Info("test", "diff", jsonValue)
+		jsonOutput := jsonBuf.String()
+
+		// Terminal should show ANSI (sanitized)
+		assert.Contains(t, termOutput, "\033[31mred text\033[0m")
+		assert.NotContains(t, termOutput, "plain text")
+
+		// JSON should show plain text via LogValue()
+		assert.Contains(t, jsonOutput, "plain text")
+		assert.NotContains(t, jsonOutput, "\033[31m")
+	})
+}
+
+func TestIsSafeANSICommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      rune
+		params   string
+		expected bool
+	}{
+		{"sgr_reset", 'm', "", true},
+		{"sgr_bold", 'm', "1", true},
+		{"sgr_red", 'm', "31", true},
+		{"sgr_bright_red", 'm', "91", true},
+		{"sgr_bg_blue", 'm', "44", true},
+		{"sgr_bright_bg_blue", 'm', "104", true},
+		{"sgr_multiple", 'm', "31;1;4", true},
+		{"sgr_unsafe_code", 'm', "50", false},
+		{"sgr_invalid_param", 'm', "abc", false},
+		{"cursor_up", 'A', "1", false},
+		{"cursor_down", 'B', "1", false},
+		{"cursor_position", 'H', "10;5", false},
+		{"erase_display", 'J', "2", false},
+		{"erase_line", 'K', "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSafeANSICommand(tt.cmd, tt.params)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEscapeRune(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    rune
+		expected string
+	}{
+		{"null_byte", '\x00', "\\x00"},
+		{"newline", '\n', "\\n"},
+		{"tab", '\t', "\\t"},
+		{"delete", '\x7f', "\\x7f"},
+		{"unicode", '🎉', "🎉"}, // Should be printable, not escaped
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.input == '🎉' {
+				// This is a printable character, so it shouldn't be escaped
+				// but let's test the escapeRune function directly
+				return
+			}
+			result := escapeRune(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestTerminalValuerWithGroups ensures TerminalValuer works correctly with slog groups
+func TestTerminalValuerWithGroups(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewTerminalTreeHandler(buf, &TerminalHandlerOptions{
+		NoColor: true,
+	})
+
+	logger := slog.New(handler.WithGroup("app"))
+
+	coloredValue := TestColoredValue{
+		plainText:    "plain diff",
+		terminalText: "\033[31m-deleted\033[0m\n\033[32m+added\033[0m",
+	}
+
+	logger.Info("changes applied", "diff", coloredValue)
+
+	output := buf.String()
+	assert.Contains(t, output, "🏷️ app")
+	assert.Contains(t, output, "\033[31m-deleted\033[0m")
+	assert.Contains(t, output, "\033[32m+added\033[0m")
+}
+
+func TestStripANSI(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "color_codes_stripped",
+			input:    "\033[31mred\033[0m \033[32mgreen\033[0m",
+			expected: "red green",
+		},
+		{
+			name:     "formatting_codes_stripped",
+			input:    "\033[1mbold\033[0m \033[3mitalic\033[0m",
+			expected: "bold italic",
+		},
+		{
+			name:     "cursor_movement_stripped",
+			input:    "\033[2Jclear screen\033[H\033[31mred\033[0m",
+			expected: "clear screenred",
+		},
+		{
+			name:     "mixed_ansi_stripped",
+			input:    "\033[31mred\033[2J\033[1mbold\033[H\033[0mreset",
+			expected: "redboldreset",
+		},
+		{
+			name:     "non_printable_chars_escaped",
+			input:    "hello\x00world\x1f\x7f",
+			expected: "hello\\x00world\\x1f\\x7f",
+		},
+		{
+			name:     "tabs_preserved",
+			input:    "hello\tworld",
+			expected: "hello\tworld",
+		},
+		{
+			name:     "empty_string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no_ansi_sequences",
+			input:    "plain text",
+			expected: "plain text",
+		},
+		{
+			name:     "incomplete_ansi_sequence",
+			input:    "\033[31incomplete",
+			expected: "incomplete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripANSI(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTerminalValue(t *testing.T) {
+	t.Run("basic_functionality", func(t *testing.T) {
+		tv := NewTerminalValue("\033[31mred text\033[0m")
+
+		// String() should return stripped text
+		assert.Equal(t, "red text", tv.String())
+
+		// TerminalValue() should return original text with ANSI
+		termVal := tv.TerminalValue()
+		assert.Equal(t, "\033[31mred text\033[0m", termVal.String())
+	})
+
+	t.Run("with_multiline_content", func(t *testing.T) {
+		tv := NewTerminalValue("\033[31m-deleted line\033[0m\n\033[32m+added line\033[0m")
+
+		assert.Equal(t, "-deleted line\n+added line", tv.String())
+		assert.Equal(t, "\033[31m-deleted line\033[0m\n\033[32m+added line\033[0m", tv.TerminalValue().String())
+	})
+
+	t.Run("with_unsafe_ansi_sequences", func(t *testing.T) {
+		tv := NewTerminalValue("\033[2J\033[31mred\033[H\033[0m")
+
+		// All ANSI sequences should be stripped for String/LogValue
+		assert.Equal(t, "red", tv.String())
+
+		// Original text preserved for TerminalValue
+		assert.Equal(t, "\033[2J\033[31mred\033[H\033[0m", tv.TerminalValue().String())
+	})
+
+	t.Run("empty_text", func(t *testing.T) {
+		tv := NewTerminalValue("")
+
+		assert.Equal(t, "", tv.String())
+		assert.Equal(t, "", tv.TerminalValue().String())
+	})
+
+	t.Run("plain_text_no_ansi", func(t *testing.T) {
+		tv := NewTerminalValue("plain text")
+
+		assert.Equal(t, "plain text", tv.String())
+		assert.Equal(t, "plain text", tv.TerminalValue().String())
+	})
+}
+
+func TestTerminalValueIntegrationWithHandlers(t *testing.T) {
+	t.Run("with_tree_handler", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		handler := NewTerminalTreeHandler(buf, &TerminalHandlerOptions{
+			NoColor: true,
+		})
+		logger := slog.New(handler)
+
+		tv := NewTerminalValue("\033[31m-deleted\033[0m\n\033[32m+added\033[0m")
+		logger.Info("changes", "diff", tv)
+
+		output := buf.String()
+		// Should show sanitized ANSI (safe colors preserved, unsafe filtered)
+		assert.Contains(t, output, "\033[31m-deleted\033[0m")
+		assert.Contains(t, output, "\033[32m+added\033[0m")
+	})
+
+	t.Run("with_json_handler", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		handler := slog.NewJSONHandler(buf, nil)
+		logger := slog.New(handler)
+
+		tv := NewTerminalValue("\033[31mred text\033[0m")
+		logger.Info("test", "value", tv)
+
+		output := buf.String()
+		// Should show plain text without ANSI
+		assert.Contains(t, output, "red text")
+		assert.NotContains(t, output, "\033[31m")
+	})
+
+	t.Run("with_line_handler", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		handler := NewTerminalLineHandler(buf, &TerminalHandlerOptions{
+			NoColor: true,
+		})
+		logger := slog.New(handler)
+
+		tv := NewTerminalValue("\033[32mgreen text\033[0m")
+		logger.Info("test", "status", tv)
+
+		output := buf.String()
+		// Should show sanitized ANSI
+		assert.Contains(t, output, "\033[32mgreen text\033[0m")
+	})
+}


### PR DESCRIPTION
This enables users to log values with ANSI terminal escape sequences (eg: for colored text) for slogxt, witohut jeopardizing other slog handlers that can't handle ANSI.